### PR TITLE
Integrate hybrid RAG into PDF Q&A app (results still short)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,155 @@
+# 📄 PDF Reader: Your AI-Powered PDF Companion
+
+![PDF Reader](https://img.shields.io/badge/PDF%20Reader-v1.0-blue.svg)
+![GitHub Release](https://img.shields.io/badge/Releases-Check%20Now-brightgreen.svg)
+
+Welcome to the **PDF Reader** repository! This application leverages advanced AI technology to help users extract valuable insights from PDF documents. With a user-friendly interface built on Streamlit, and powered by cutting-edge NLP models from Transformers and Langchain, this tool makes PDF analysis straightforward and efficient.
+
+[Check out the latest releases here!](https://github.com/RiddyMazumder/PDF-Reader/releases)
+
+---
+
+## 🚀 Features
+
+- **AI-Powered Extraction**: Utilize state-of-the-art NLP models to extract relevant information from your PDF documents.
+- **User-Friendly Interface**: Built with Streamlit, the application offers an intuitive experience for all users.
+- **Seamless PDF Upload**: Easily upload your PDFs and start extracting information in seconds.
+- **Advanced Analysis**: Analyze the content of your PDFs to gain deeper insights and understanding.
+
+---
+
+## 📚 Table of Contents
+
+1. [Installation](#installation)
+2. [Usage](#usage)
+3. [Technologies Used](#technologies-used)
+4. [Contributing](#contributing)
+5. [License](#license)
+6. [Support](#support)
+
+---
+
+## 🛠️ Installation
+
+To get started with the PDF Reader, follow these steps:
+
+1. **Clone the Repository**: 
+
+   ```bash
+   git clone https://github.com/RiddyMazumder/PDF-Reader.git
+   ```
+
+2. **Navigate to the Directory**:
+
+   ```bash
+   cd PDF-Reader
+   ```
+
+3. **Install Dependencies**:
+
+   Ensure you have Python 3.7 or higher installed. Then, run:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Run the Application**:
+
+   Start the Streamlit app with the following command:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+Now, you can access the PDF Reader on your local server.
+
+---
+
+## 📖 Usage
+
+Using the PDF Reader is simple:
+
+1. Open your web browser and navigate to the local server address provided by Streamlit.
+2. Upload your PDF document using the upload button.
+3. Once uploaded, click on the "Extract" button to retrieve meaningful information from the document.
+4. Review the extracted data displayed on the screen.
+
+For a deeper dive into the analysis features, refer to the [Releases](https://github.com/RiddyMazumder/PDF-Reader/releases) section for updates and enhancements.
+
+---
+
+## 🧩 Technologies Used
+
+This project incorporates several powerful technologies:
+
+- **Streamlit**: A framework for building interactive web applications quickly.
+- **Transformers**: A library by Hugging Face for state-of-the-art NLP models.
+- **Langchain**: A framework that facilitates the integration of language models into applications.
+- **Python**: The primary programming language used for development.
+- **Pandas**: For data manipulation and analysis.
+
+The combination of these technologies allows for robust PDF analysis and extraction capabilities.
+
+---
+
+## 🤝 Contributing
+
+We welcome contributions from the community! If you want to help improve the PDF Reader, follow these steps:
+
+1. **Fork the Repository**.
+2. **Create a New Branch**:
+
+   ```bash
+   git checkout -b feature/YourFeatureName
+   ```
+
+3. **Make Your Changes**.
+4. **Commit Your Changes**:
+
+   ```bash
+   git commit -m "Add your message here"
+   ```
+
+5. **Push to the Branch**:
+
+   ```bash
+   git push origin feature/YourFeatureName
+   ```
+
+6. **Open a Pull Request**.
+
+Please ensure your code follows the project's coding standards and includes appropriate tests.
+
+---
+
+## 📄 License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+---
+
+## 📞 Support
+
+If you encounter any issues or have questions, please check the [Releases](https://github.com/RiddyMazumder/PDF-Reader/releases) section for updates. You can also open an issue in the repository for support.
+
+---
+
+## 🎉 Acknowledgments
+
+We thank the developers and contributors of the technologies used in this project. Their hard work and dedication make this application possible.
+
+---
+
+## 🌟 Future Improvements
+
+We aim to continuously enhance the PDF Reader. Here are some features we plan to implement:
+
+- **Multi-Language Support**: Allow users to analyze PDFs in different languages.
+- **Batch Processing**: Enable users to upload and analyze multiple PDFs at once.
+- **Export Options**: Provide users with the ability to export extracted data in various formats (CSV, JSON, etc.).
+
+Stay tuned for updates in the [Releases](https://github.com/RiddyMazumder/PDF-Reader/releases) section!
+
+---
+
+Thank you for checking out the PDF Reader. We hope it helps you unlock the potential of your PDF documents!

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -3,8 +3,26 @@ from langchain.document_loaders import PyPDFLoader
 from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.chains import RetrievalQA
 from langchain.llms import HuggingFacePipeline
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from transformers import pipeline
 
+def _device():
+    try:
+        # check if torch and cuda are available
+        import torch
+        return 0 if torch.cuda.is_available() else -1
+    except Exception:
+        return -1 # if no torch, use cpu
+
+def _extractive_pipeline():
+    # span extractor
+    return pipeline("question-answering", model="deepset/roberta-base-squad2", device=_device())
+
+def _generative_llm():
+    # small, local-friendly text2text model; works with RetrievalQA
+    gen = pipeline("text2text-generation", model="google/flan-t5-base", device=_device())
+    return HuggingFacePipeline(pipeline=gen)
+    
 def load_documents(pdf_paths):
     all_documents = []
     for path in pdf_paths:
@@ -14,16 +32,24 @@ def load_documents(pdf_paths):
     return all_documents
 
 def create_vector_store(documents):
+    
+    # split documents into smaller chunks
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    chunks = splitter.split_documents(documents)
+    
+    # create vector store
     embedding_model = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-    vector_store = FAISS.from_documents(documents, embedding_model)
+    vector_store = FAISS.from_documents(chunks, embedding_model)
     return vector_store
 
 def search_documents(query, documents):
     # Create vector store
     vector_store = create_vector_store(documents)
+    retriever = vector_store.as_retriever(search_kwargs={"k": 10})
 
     # Load QA pipeline with extractive model
     qa_pipeline = pipeline("question-answering", model="deepset/roberta-base-squad2")
+
     llm = HuggingFacePipeline(pipeline=qa_pipeline)
 
     # Create Retrieval QA chain

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -65,21 +65,17 @@ def search_documents(query, documents):
             pass  
 
     if best["answer"] and best["score"] > 0.1 and not _is_openended(query):  # if we found a decent answer, return it
-
+        return best["answer"]
 
     # generative llm for open-ended questions or if no good extractive answer found
     gen_llm = _generative_llm() 
     # Create Retrieval QA chain
     qa_chain = RetrievalQA.from_chain_type(
         llm=gen_llm,
-        retriever=retrieve,
+        retriever=retriever,
         return_source_documents=False
     )
 
     # Ask question
     answer = qa_chain.run(query)
     return answer
-
-
-
-


### PR DESCRIPTION
This PR aims to modify `rag_engine.py` so that extractive QA is used for factoid queries and gen QA is used for open-ended ones. 
Known issue: generative answers are still very short (1–2 words) and very resume-parsing-oriented. The pipeline integration 'works', but model choice/parameters likely need tuning to produce longer, more natural answers.